### PR TITLE
refactor: separate daily habit insert types and add server build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "build": "vite build && tsc --project tsconfig.server.json",
-    "start": "tsx watch scripts/dev.ts",
+    "build:server": "tsc -p tsconfig.server.json",
+    "render-build": "npm run build:server",
+    "start": "node dist/server/server/index.js",
     "generate-vapid": "node scripts/generate-vapid.js"
   },
   "dependencies": {

--- a/server/database.ts
+++ b/server/database.ts
@@ -1,4 +1,4 @@
-import { Kysely, SqliteDialect } from 'kysely';
+import { Kysely, SqliteDialect, Generated, ColumnType } from 'kysely';
 import Database from 'better-sqlite3';
 import path from 'path';
 
@@ -24,7 +24,7 @@ export interface DatabaseSchema {
     created_at: string;
   };
   daily_habits: {
-    id: number;
+    id: Generated<number>;
     user_id: number;
     date: string;
     training_completed: number;
@@ -33,8 +33,8 @@ export interface DatabaseSchema {
     meditation_completed: number;
     daily_points: number;
     steps: number;
-    created_at: string;
-    updated_at: string;
+    created_at: ColumnType<string, string | undefined>;
+    updated_at: ColumnType<string, string | undefined>;
   };
   daily_history: {
     id: number;

--- a/server/routes/daily-habits-routes.ts
+++ b/server/routes/daily-habits-routes.ts
@@ -1,8 +1,10 @@
 import { Router } from 'express';
 import { db } from '../database.js';
 import { authenticateToken } from '../middleware/auth.js';
-import { sendErrorResponse, ERROR_CODES } from '../utils/validation.js';
+import { sendErrorResponse, ERROR_CODES, validateRequest } from '../utils/validation.js';
 import { SystemLogger } from '../utils/logging.js';
+import { DailyHabitInsert } from '../types/daily-habits.js';
+import { DailyHabitInsertSchema } from '../utils/schemas.js';
 
 const router = Router();
 
@@ -23,23 +25,24 @@ router.get('/daily-habits/today', authenticateToken, async (req: any, res) => {
 
     if (!todayHabits) {
       // Create default record for today
+      const payload: DailyHabitInsert = {
+        user_id: userId,
+        date: today,
+        training_completed: 0,
+        nutrition_completed: 0,
+        movement_completed: 0,
+        meditation_completed: 0,
+        daily_points: 0,
+        steps: 0,
+      };
+
       todayHabits = await db
         .insertInto('daily_habits')
-        .values({
-          user_id: userId,
-          date: today,
-          training_completed: 0,
-          nutrition_completed: 0,
-          movement_completed: 0,
-          meditation_completed: 0,
-          daily_points: 0,
-          steps: 0,
-          created_at: new Date().toISOString(),
-          updated_at: new Date().toISOString()
-        })
+        .values(payload)
         .returning([
-          'id', 'user_id', 'date', 'training_completed', 'nutrition_completed', 
-          'movement_completed', 'meditation_completed', 'daily_points', 'steps'
+          'id', 'user_id', 'date', 'training_completed', 'nutrition_completed',
+          'movement_completed', 'meditation_completed', 'daily_points', 'steps',
+          'created_at', 'updated_at'
         ])
         .executeTakeFirst();
     }
@@ -119,98 +122,70 @@ router.get('/daily-habits/calendar', authenticateToken, async (req: any, res) =>
 });
 
 // Update daily habits
-router.put('/daily-habits/update', authenticateToken, async (req: any, res) => {
-  try {
-    const userId = req.user.id;
-    const { 
-      date, 
-      training_completed, 
-      nutrition_completed, 
-      movement_completed, 
-      meditation_completed, 
-      steps 
-    } = req.body;
-    
-    console.log('Updating daily habits for user:', userId, 'date:', date, 'data:', req.body);
+router.put(
+  '/daily-habits/update',
+  authenticateToken,
+  validateRequest(DailyHabitInsertSchema, 'body'),
+  async (req: any, res) => {
+    try {
+      const userId = req.user.id;
+      const payload = req.body as DailyHabitInsert;
+      payload.user_id = userId;
 
-    if (!date) {
-      sendErrorResponse(res, ERROR_CODES.VALIDATION_ERROR, 'Fecha requerida');
-      return;
-    }
+      console.log('Updating daily habits for user:', userId, 'date:', payload.date, 'data:', payload);
 
-    // Get current record or create new one
-    let currentHabits = await db
-      .selectFrom('daily_habits')
-      .selectAll()
-      .where('user_id', '=', userId)
-      .where('date', '=', date)
-      .executeTakeFirst();
+      // Recalculate daily points based on completed habits
+      payload.daily_points =
+        payload.training_completed +
+        payload.nutrition_completed +
+        payload.movement_completed +
+        payload.meditation_completed;
 
-    const updateData: any = {
-      updated_at: new Date().toISOString()
-    };
-
-    // Update fields that were provided
-    if (training_completed !== undefined) updateData.training_completed = training_completed ? 1 : 0;
-    if (nutrition_completed !== undefined) updateData.nutrition_completed = nutrition_completed ? 1 : 0;
-    if (movement_completed !== undefined) updateData.movement_completed = movement_completed ? 1 : 0;
-    if (meditation_completed !== undefined) updateData.meditation_completed = meditation_completed ? 1 : 0;
-    if (steps !== undefined) updateData.steps = steps;
-
-    // Calculate points based on completed habits
-    const habitsToCheck = {
-      training_completed: training_completed !== undefined ? (training_completed ? 1 : 0) : (currentHabits?.training_completed || 0),
-      nutrition_completed: nutrition_completed !== undefined ? (nutrition_completed ? 1 : 0) : (currentHabits?.nutrition_completed || 0),
-      movement_completed: movement_completed !== undefined ? (movement_completed ? 1 : 0) : (currentHabits?.movement_completed || 0),
-      meditation_completed: meditation_completed !== undefined ? (meditation_completed ? 1 : 0) : (currentHabits?.meditation_completed || 0)
-    };
-
-    const dailyPoints = Object.values(habitsToCheck).reduce((sum, completed) => sum + completed, 0);
-    updateData.daily_points = dailyPoints;
-
-    let result;
-    if (currentHabits) {
-      // Update existing record
-      result = await db
-        .updateTable('daily_habits')
-        .set(updateData)
+      const currentHabits = await db
+        .selectFrom('daily_habits')
+        .selectAll()
         .where('user_id', '=', userId)
-        .where('date', '=', date)
-        .returning([
-          'id', 'user_id', 'date', 'training_completed', 'nutrition_completed',
-          'movement_completed', 'meditation_completed', 'daily_points', 'steps'
-        ])
+        .where('date', '=', payload.date)
         .executeTakeFirst();
-    } else {
-      // Create new record
-      result = await db
-        .insertInto('daily_habits')
-        .values({
-          user_id: userId,
-          date: date,
-          training_completed: updateData.training_completed || 0,
-          nutrition_completed: updateData.nutrition_completed || 0,
-          movement_completed: updateData.movement_completed || 0,
-          meditation_completed: updateData.meditation_completed || 0,
-          daily_points: dailyPoints,
-          steps: updateData.steps || 0,
-          created_at: new Date().toISOString(),
-          updated_at: new Date().toISOString()
-        })
-        .returning([
-          'id', 'user_id', 'date', 'training_completed', 'nutrition_completed',
-          'movement_completed', 'meditation_completed', 'daily_points', 'steps'
-        ])
-        .executeTakeFirst();
-    }
 
-    console.log('Daily habits updated successfully:', result);
-    res.json(result);
-  } catch (error) {
-    console.error('Error updating daily habits:', error);
-    await SystemLogger.logCriticalError('Daily habits update error', error as Error, { userId: req.user?.id });
-    sendErrorResponse(res, ERROR_CODES.SERVER_ERROR, 'Error al actualizar hábitos diarios');
+      let result;
+      if (currentHabits) {
+        result = await db
+          .updateTable('daily_habits')
+          .set({
+            training_completed: payload.training_completed,
+            nutrition_completed: payload.nutrition_completed,
+            movement_completed: payload.movement_completed,
+            meditation_completed: payload.meditation_completed,
+            daily_points: payload.daily_points,
+            steps: payload.steps,
+          })
+          .where('user_id', '=', userId)
+          .where('date', '=', payload.date)
+          .returning([
+            'id', 'user_id', 'date', 'training_completed', 'nutrition_completed',
+            'movement_completed', 'meditation_completed', 'daily_points', 'steps'
+          ])
+          .executeTakeFirst();
+      } else {
+        result = await db
+          .insertInto('daily_habits')
+          .values(payload)
+          .returning([
+            'id', 'user_id', 'date', 'training_completed', 'nutrition_completed',
+            'movement_completed', 'meditation_completed', 'daily_points', 'steps'
+          ])
+          .executeTakeFirst();
+      }
+
+      console.log('Daily habits updated successfully:', result);
+      res.json(result);
+    } catch (error) {
+      console.error('Error updating daily habits:', error);
+      await SystemLogger.logCriticalError('Daily habits update error', error as Error, { userId: req.user?.id });
+      sendErrorResponse(res, ERROR_CODES.SERVER_ERROR, 'Error al actualizar hábitos diarios');
+    }
   }
-});
+);
 
 export default router;

--- a/server/types/daily-habits.ts
+++ b/server/types/daily-habits.ts
@@ -1,0 +1,16 @@
+export interface DailyHabitBase {
+  date: string;
+  user_id: number;
+  training_completed: number;
+  nutrition_completed: number;
+  movement_completed: number;
+  meditation_completed: number;
+  daily_points: number;
+  steps: number;
+}
+export interface DailyHabitRow extends DailyHabitBase {
+  id: number;
+  created_at: string;
+  updated_at: string;
+}
+export type DailyHabitInsert = Omit<DailyHabitRow, 'id' | 'created_at' | 'updated_at'>;

--- a/server/utils/schemas.ts
+++ b/server/utils/schemas.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const DailyHabitInsertSchema = z.object({
+  date: z.string(),
+  user_id: z.number().int().positive(),
+  training_completed: z.number().int().min(0).max(1),
+  nutrition_completed: z.number().int().min(0).max(1),
+  movement_completed: z.number().int().min(0).max(1),
+  meditation_completed: z.number().int().min(0).max(1),
+  daily_points: z.number().int().min(0),
+  steps: z.number().int().min(0),
+});


### PR DESCRIPTION
## Summary
- add DailyHabitBase, DailyHabitRow and DailyHabitInsert types
- validate daily habit payloads with DailyHabitInsertSchema
- adjust routes and database schema to handle generated timestamps
- add server-only build scripts for Render and update start command

## Testing
- `npm run build`
- `tsc --project tsconfig.server.json`
- `npm run build:server`


------
https://chatgpt.com/codex/tasks/task_e_68b84e917a6c832890f9a0650a09a97d